### PR TITLE
CI: Ensure code coverage reporting will work in February 2022 and beyond

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,12 +27,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install pari-gp
-      - uses: gap-actions/setup-gap-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
         with:
           #GAP_PKGS_TO_CLONE: "nq"    # WORKAROUND issue in nq 2.5.3
           GAP_PKGS_TO_BUILD: "nq io profiling"
           GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/run-test-for-packages@v1
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v2
 
   # The documentation job
   manual:
@@ -43,11 +46,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
         with:
           #GAP_PKGS_TO_CLONE: "nq"    # WORKAROUND issue in nq 2.5.3
           GAP_PKGS_TO_BUILD: "nq io profiling"
-      - uses: gap-actions/compile-documentation-for-packages@v1
+      - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
       - name: 'Upload documentation'


### PR DESCRIPTION
See https://github.com/gap-actions/process-coverage/issues/10
